### PR TITLE
Add strict EEND dialogue shard loader

### DIFF
--- a/config/data/dialogue_preprocessed_eend.yaml
+++ b/config/data/dialogue_preprocessed_eend.yaml
@@ -1,0 +1,14 @@
+datamodule:
+  _target_: sidon.data.preprocess.preprocessed_dialogue_datamodule.PreprocessedDialogueDataModule
+  train_urls: []
+  val_urls: []
+  batch_size: 2
+  val_batch_size: 2
+  train_num_workers: 0
+  val_num_workers: 0
+  preprocessed: true
+  is_s3: false
+  required_sample_rate: 24000
+  expected_duration_seconds: 20
+  required_input_channels: 2
+  require_noisy_16k_mixture: true

--- a/src/sidon/data/__init__.py
+++ b/src/sidon/data/__init__.py
@@ -1,6 +1,15 @@
 """Dataset helpers for Sidon."""
 
+from typing import Any
+
 from .datamodule import PreprocessedDataModule, torch_audio
-from .preprocess import WebDatasetDataModule
 
 __all__ = ["PreprocessedDataModule", "WebDatasetDataModule", "torch_audio"]
+
+
+def __getattr__(name: str) -> Any:
+    if name == "WebDatasetDataModule":
+        from .preprocess import WebDatasetDataModule
+
+        return WebDatasetDataModule
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/src/sidon/data/datamodule.py
+++ b/src/sidon/data/datamodule.py
@@ -1,17 +1,21 @@
 """Data module implementations for Sidon."""
 from __future__ import annotations
 
+import importlib
 import io
 import os
 import random
 import re
+import shlex
 from pathlib import Path
 from typing import Any, Dict, Iterable, Sequence
+from urllib.parse import urlsplit
 
 import torch
 import torchaudio
-import webdataset as wds
 from lightning.pytorch import LightningDataModule
+
+wds = importlib.import_module("webdataset")
 
 
 def torch_audio(key: str, data: bytes):
@@ -42,9 +46,23 @@ def get_urls(path: Sequence[str] | str) -> list[str]:
     urls: list[str] = []
     for entry in path:
         with Path(entry).open("r", encoding="utf-8") as file_handle:
-            for line in file_handle.read().splitlines():
+            for line_number, line in enumerate(file_handle.read().splitlines(), start=1):
+                uri = line.strip()
+                parsed = urlsplit(uri)
+                if (
+                    parsed.scheme != "s3"
+                    or not parsed.netloc
+                    or parsed.path in {"", "/"}
+                    or parsed.query
+                    or parsed.fragment
+                    or any(ord(character) < 32 or ord(character) == 127 for character in uri)
+                ):
+                    raise ValueError(
+                        f"invalid S3 URI in {entry} at line {line_number}: {uri!r}"
+                    )
                 urls.append(
-                    f"pipe:aws --endpoint-url https://s3ds.mdx.jp s3 cp {line} -"
+                    "pipe:aws --endpoint-url https://s3ds.mdx.jp s3 cp "
+                    f"{shlex.quote(uri)} -"
                 )
     return urls
 
@@ -79,7 +97,7 @@ def _contains_nan(value: Any) -> bool:
     """Recursively inspect tensors nested in mappings/sequences for NaNs."""
     if isinstance(value, torch.Tensor):
         if value.is_floating_point() or torch.is_complex(value):
-            return torch.isnan(value).any().item()
+            return bool(torch.isnan(value).any().item())
         return False
     if isinstance(value, dict):
         return any(_contains_nan(v) for v in value.values())
@@ -165,7 +183,7 @@ class PreprocessedDataModule(LightningDataModule):
             .batched(self.val_batch_size, collation_fn=self.collate_fn)
         )
 
-    def train_dataloader(self) -> wds.WebLoader:
+    def train_dataloader(self) -> Any:
         return wds.WebLoader(
             self.train_dataset,
             num_workers=self.train_num_workers,
@@ -175,7 +193,7 @@ class PreprocessedDataModule(LightningDataModule):
             drop_last=True,
         )
 
-    def val_dataloader(self) -> wds.WebLoader:
+    def val_dataloader(self) -> Any:
         return wds.WebLoader(
             self.val_dataset,
             num_workers=self.val_num_workers,

--- a/src/sidon/data/preprocess/__init__.py
+++ b/src/sidon/data/preprocess/__init__.py
@@ -1,5 +1,13 @@
 """Preprocessing data modules and utilities for creating WebDataset shards."""
 
-from .webdataset_datamodule import WebDatasetDataModule
+from typing import Any
 
 __all__ = ["WebDatasetDataModule"]
+
+
+def __getattr__(name: str) -> Any:
+    if name == "WebDatasetDataModule":
+        from .webdataset_datamodule import WebDatasetDataModule
+
+        return WebDatasetDataModule
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/src/sidon/data/preprocess/preprocessed_dialogue_datamodule.py
+++ b/src/sidon/data/preprocess/preprocessed_dialogue_datamodule.py
@@ -1,0 +1,447 @@
+from __future__ import annotations
+
+import io
+import importlib
+import json
+import re
+import tarfile
+from typing import Any, Iterable, Iterator, NoReturn, Sequence
+
+import torch
+import torch.nn.functional as F
+
+from ..datamodule import PreprocessedDataModule, skip_nan_preprocessed
+
+
+wds = importlib.import_module("webdataset")
+wds_filters = importlib.import_module("webdataset.filters")
+
+_MAX_TENSOR_PAYLOAD_BYTES = 64 * 1024 * 1024
+_MAX_METADATA_PAYLOAD_BYTES = 4 * 1024 * 1024
+_MAX_EXTENSION_HEADER_BYTES = 4 * 1024
+_ALLOWED_TENSOR_FIELDS = frozenset(
+    {
+        ".input_wav.pth",
+        ".noisy_input_wav.pth",
+        ".noisy_input_wav16k.pth",
+        ".clean_mixture.pth",
+        ".clean_16k_mixture.pth",
+        ".noisy_mixture.pth",
+        ".noisy_16k_mixture.pth",
+    }
+)
+_OPTIONAL_TENSOR_FIELDS = (
+    "noisy_input_wav.pth",
+    "noisy_input_wav16k.pth",
+    "clean_mixture.pth",
+    "clean_16k_mixture.pth",
+    "noisy_mixture.pth",
+    "noisy_16k_mixture.pth",
+)
+_MEMBER_SIZE_LIMITS = {
+    **{
+        field.removeprefix("."): _MAX_TENSOR_PAYLOAD_BYTES
+        for field in _ALLOWED_TENSOR_FIELDS
+    },
+    "sr.index": 64,
+    "manifest.json": _MAX_METADATA_PAYLOAD_BYTES,
+}
+_RECORD_KEY_PATTERN = re.compile(r"[A-Za-z0-9][A-Za-z0-9_-]{0,254}")
+
+
+class BoundedTarInfo(tarfile.TarInfo):
+    def _validate_extension_header_size(self) -> None:
+        if self.size < 0 or self.size > _MAX_EXTENSION_HEADER_BYTES:
+            raise ValueError("tar extension header exceeds size limit")
+
+    def _proc_gnulong(self, archive: tarfile.TarFile) -> tarfile.TarInfo:
+        self._validate_extension_header_size()
+        return getattr(super(), "_proc_gnulong")(archive)
+
+    def _proc_pax(self, archive: tarfile.TarFile) -> tarfile.TarInfo:
+        self._validate_extension_header_size()
+        return getattr(super(), "_proc_pax")(archive)
+
+    def _proc_sparse(self, archive: tarfile.TarFile) -> tarfile.TarInfo:
+        del archive
+        self._reject_sparse_entry()
+
+    def _proc_gnusparse_00(self, next_member: Any, raw_headers: Any) -> NoReturn:
+        del next_member, raw_headers
+        self._reject_sparse_entry()
+
+    def _proc_gnusparse_01(self, next_member: Any, pax_headers: Any) -> NoReturn:
+        del next_member, pax_headers
+        self._reject_sparse_entry()
+
+    def _proc_gnusparse_10(
+        self,
+        next_member: Any,
+        pax_headers: Any,
+        archive: tarfile.TarFile,
+    ) -> NoReturn:
+        del next_member, pax_headers, archive
+        self._reject_sparse_entry()
+
+    @staticmethod
+    def _reject_sparse_entry() -> NoReturn:
+        raise ValueError("tar sparse entries are disabled")
+
+
+def _parse_member_name(name: str) -> tuple[str, str]:
+    for suffix in sorted(_MEMBER_SIZE_LIMITS, key=len, reverse=True):
+        separator = f".{suffix}"
+        if name.endswith(separator):
+            record_key = name[: -len(separator)]
+            if _RECORD_KEY_PATTERN.fullmatch(record_key) is None:
+                raise ValueError(f"tar member has an unsafe record key: {name!r}")
+            return record_key, suffix
+    raise ValueError(f"tar member has an unsupported suffix: {name!r}")
+
+
+def bounded_tar_file_iterator(fileobj: Any) -> Iterator[dict[str, Any]]:
+    with tarfile.open(
+        fileobj=fileobj,
+        mode="r|*",
+        tarinfo=BoundedTarInfo,
+    ) as archive:
+        for tar_info in archive:
+            if not tar_info.isreg():
+                raise ValueError(f"tar member must be a regular file: {tar_info.name!r}")
+            _, suffix = _parse_member_name(tar_info.name)
+            size_limit = _MEMBER_SIZE_LIMITS[suffix]
+            if tar_info.size < 0 or tar_info.size > size_limit:
+                raise ValueError(
+                    f"tar member exceeds size limit: {tar_info.name!r}, "
+                    f"size={tar_info.size}, limit={size_limit}"
+                )
+            extracted = archive.extractfile(tar_info)
+            if extracted is None:
+                raise ValueError(f"cannot read tar member: {tar_info.name!r}")
+            yield {"fname": tar_info.name, "data": extracted.read()}
+            setattr(archive, "members", [])
+
+
+def bounded_tar_file_expander(
+    sources: Iterable[dict[str, Any]],
+) -> Iterator[dict[str, Any]]:
+    for source in sources:
+        if "stream" not in source or "url" not in source:
+            raise ValueError("WebDataset source must contain stream and url")
+        for sample in bounded_tar_file_iterator(source["stream"]):
+            sample["__url__"] = source["url"]
+            if "local_path" in source:
+                sample["__local_path__"] = source["local_path"]
+            yield sample
+        yield {}
+
+
+_bounded_tar_file_expander_stage = wds_filters.pipelinefilter(
+    bounded_tar_file_expander
+)
+
+
+def _bounded_webdataset(urls: Sequence[str], *, shardshuffle: int | bool) -> Any:
+    dataset = wds.WebDataset(
+        urls,
+        shardshuffle=shardshuffle,
+        nodesplitter=lambda values: values,
+        workersplitter=wds.split_by_worker,
+        repeat=True,
+        empty_check=True,
+        handler=wds.reraise_exception,
+    )
+    expander_indices = [
+        index
+        for index, pipeline_stage in enumerate(dataset.pipeline)
+        if getattr(getattr(pipeline_stage, "f", None), "__name__", None)
+        == "tar_file_expander"
+    ]
+    if len(expander_indices) != 1:
+        raise RuntimeError("unsupported WebDataset pipeline: tar expander not found")
+    dataset.pipeline[expander_indices[0]] = _bounded_tar_file_expander_stage()
+    return dataset
+
+
+def safe_dialogue_decoder(key: str, data: bytes) -> object | None:
+    normalized = key.lower()
+    if normalized.endswith((".pickle", ".pkl")):
+        raise ValueError(f"pickle payloads are disabled: {key}")
+    if normalized.endswith(".pth"):
+        if normalized not in _ALLOWED_TENSOR_FIELDS:
+            raise ValueError(f"tensor payload is not allowlisted: {key}")
+        if not isinstance(data, bytes):
+            raise TypeError(f"{key} must contain bytes")
+        if len(data) > _MAX_TENSOR_PAYLOAD_BYTES:
+            raise ValueError(f"{key} exceeds the tensor payload size limit")
+        try:
+            value = torch.load(
+                io.BytesIO(data),
+                map_location="cpu",
+                weights_only=True,
+            )
+        except Exception as error:
+            raise ValueError(f"{key} is not a safe tensor payload") from error
+        if not isinstance(value, torch.Tensor):
+            raise ValueError(f"{key} must contain exactly one tensor")
+        if value.numel() * value.element_size() > _MAX_TENSOR_PAYLOAD_BYTES:
+            raise ValueError(f"{key} decoded tensor exceeds the size limit")
+        return value
+    if normalized.endswith(".index"):
+        if not isinstance(data, bytes) or len(data) > 64:
+            raise ValueError(f"{key} is not a valid index payload")
+        try:
+            return int(data.decode("ascii").strip())
+        except (UnicodeDecodeError, ValueError) as error:
+            raise ValueError(f"{key} is not a valid integer index") from error
+    if normalized.endswith(".json"):
+        if not isinstance(data, bytes) or len(data) > _MAX_METADATA_PAYLOAD_BYTES:
+            raise ValueError(f"{key} exceeds the JSON payload size limit")
+        try:
+            return json.loads(data.decode("utf-8"))
+        except (UnicodeDecodeError, json.JSONDecodeError) as error:
+            raise ValueError(f"{key} is not valid JSON") from error
+    return None
+
+
+class PreprocessedDialogueDataModule(PreprocessedDataModule):
+    """Load channel-preserving dialogue tensors from completed shards."""
+
+    def __init__(
+        self,
+        train_urls: Sequence[str] | str,
+        val_urls: Sequence[str] | str,
+        batch_size: int,
+        val_batch_size: int,
+        train_num_workers: int = 0,
+        val_num_workers: int = 0,
+        preprocessed: bool = True,
+        is_s3: bool = False,
+        required_sample_rate: int | None = None,
+        expected_duration_seconds: int | None = None,
+        required_input_channels: int | None = None,
+        require_noisy_16k_mixture: bool = False,
+    ) -> None:
+        super().__init__(
+            train_urls=train_urls,
+            val_urls=val_urls,
+            batch_size=batch_size,
+            val_batch_size=val_batch_size,
+            train_num_workers=train_num_workers,
+            val_num_workers=val_num_workers,
+            preprocessed=preprocessed,
+            is_s3=is_s3,
+        )
+        if required_sample_rate is not None and (
+            isinstance(required_sample_rate, bool)
+            or not isinstance(required_sample_rate, int)
+            or required_sample_rate <= 0
+        ):
+            raise ValueError("required_sample_rate must be a positive integer")
+        if expected_duration_seconds is not None and (
+            isinstance(expected_duration_seconds, bool)
+            or not isinstance(expected_duration_seconds, int)
+            or expected_duration_seconds <= 0
+        ):
+            raise ValueError("expected_duration_seconds must be a positive integer")
+        if required_input_channels is not None and (
+            isinstance(required_input_channels, bool)
+            or not isinstance(required_input_channels, int)
+            or required_input_channels <= 0
+        ):
+            raise ValueError("required_input_channels must be a positive integer")
+        if not isinstance(require_noisy_16k_mixture, bool):
+            raise ValueError("require_noisy_16k_mixture must be boolean")
+        self.required_sample_rate = required_sample_rate
+        self.expected_duration_seconds = expected_duration_seconds
+        self.required_input_channels = required_input_channels
+        self.require_noisy_16k_mixture = require_noisy_16k_mixture
+
+    def setup(self, stage: str | None = None) -> None:
+        del stage
+        self.train_dataset = (
+            _bounded_webdataset(self.train_urls, shardshuffle=100)
+            .decode(
+                safe_dialogue_decoder,
+                handler=wds.reraise_exception,
+                pre=[],
+                post=[],
+            )
+            .compose(skip_nan_preprocessed)
+            .shuffle(100)
+            .batched(self.batch_size, collation_fn=self.collate_fn)
+        )
+        self.val_dataset = (
+            _bounded_webdataset(self.val_urls, shardshuffle=False)
+            .decode(
+                safe_dialogue_decoder,
+                handler=wds.reraise_exception,
+                pre=[],
+                post=[],
+            )
+            .compose(skip_nan_preprocessed)
+            .batched(self.val_batch_size, collation_fn=self.collate_fn)
+        )
+
+    @staticmethod
+    def _as_batched(tensor: torch.Tensor) -> torch.Tensor:
+        if tensor.dim() == 1:
+            return tensor.unsqueeze(0).unsqueeze(0)
+        if tensor.dim() == 2:
+            return tensor.unsqueeze(0)
+        return tensor
+
+    @classmethod
+    def _pad_cat(cls, tensors: list[torch.Tensor]) -> torch.Tensor:
+        if not tensors:
+            return torch.empty(0)
+        batched = [cls._as_batched(tensor) for tensor in tensors]
+        max_length = max(tensor.size(-1) for tensor in batched)
+        padded = [
+            F.pad(tensor, (0, max_length - tensor.size(-1)))
+            for tensor in batched
+        ]
+        return torch.cat(padded, dim=0)
+
+    def _strict_contract_enabled(self) -> bool:
+        return any(
+            value is not None
+            for value in (
+                self.required_sample_rate,
+                self.expected_duration_seconds,
+                self.required_input_channels,
+            )
+        ) or self.require_noisy_16k_mixture
+
+    def _validate_samples(self, samples: list[dict[str, Any]]) -> None:
+        if not samples:
+            raise ValueError("preprocessed dialogue batch must not be empty")
+        strict = self._strict_contract_enabled()
+        required_keys = {"input_wav.pth"}
+        if strict:
+            required_keys.add("sr.index")
+        if self.require_noisy_16k_mixture:
+            required_keys.add("noisy_16k_mixture.pth")
+        for index, sample in enumerate(samples):
+            missing = sorted(required_keys - sample.keys())
+            if missing:
+                raise ValueError(
+                    f"sample {index} is missing required payloads: {', '.join(missing)}"
+                )
+            input_wav = sample["input_wav.pth"]
+            if not isinstance(input_wav, torch.Tensor) or not input_wav.is_floating_point():
+                raise ValueError(f"sample {index} input_wav.pth must be a float tensor")
+            if input_wav.dim() not in (1, 2):
+                raise ValueError(
+                    f"sample {index} input_wav.pth must not contain an inner batch dimension"
+                )
+            if not torch.isfinite(input_wav).all():
+                raise ValueError(f"sample {index} input_wav.pth must be finite")
+            for payload_key in _OPTIONAL_TENSOR_FIELDS:
+                if payload_key not in sample:
+                    continue
+                payload = sample[payload_key]
+                if not isinstance(payload, torch.Tensor) or not payload.is_floating_point():
+                    raise ValueError(
+                        f"sample {index} {payload_key} must be a float tensor"
+                    )
+                if payload.dim() not in (1, 2):
+                    raise ValueError(
+                        f"sample {index} {payload_key} must not contain an inner batch dimension"
+                    )
+                if not torch.isfinite(payload).all():
+                    raise ValueError(f"sample {index} {payload_key} must be finite")
+            if not strict:
+                continue
+            if self.required_input_channels is not None and (
+                input_wav.dim() != 2
+                or input_wav.size(0) != self.required_input_channels
+            ):
+                raise ValueError(
+                    f"sample {index} input_wav.pth must have "
+                    f"{self.required_input_channels} channels"
+                )
+            if self.required_sample_rate is not None and (
+                sample["sr.index"] != self.required_sample_rate
+            ):
+                raise ValueError(
+                    f"sample {index} sr.index must be {self.required_sample_rate}"
+                )
+            if (
+                self.expected_duration_seconds is not None
+                and self.required_sample_rate is not None
+                and input_wav.size(-1)
+                != self.expected_duration_seconds * self.required_sample_rate
+            ):
+                raise ValueError(
+                    f"sample {index} input_wav.pth has an unexpected duration"
+                )
+            if self.require_noisy_16k_mixture:
+                mixture = sample["noisy_16k_mixture.pth"]
+                if (
+                    not isinstance(mixture, torch.Tensor)
+                    or not mixture.is_floating_point()
+                    or mixture.dim() != 1
+                ):
+                    raise ValueError(
+                        f"sample {index} noisy_16k_mixture.pth must be a 1D float tensor"
+                    )
+                if not torch.isfinite(mixture).all():
+                    raise ValueError(
+                        f"sample {index} noisy_16k_mixture.pth must be finite"
+                    )
+                if (
+                    self.expected_duration_seconds is not None
+                    and mixture.size(-1) != self.expected_duration_seconds * 16_000
+                ):
+                    raise ValueError(
+                        f"sample {index} noisy_16k_mixture.pth has an unexpected duration"
+                    )
+
+    def collate_fn(self, samples: list[dict[str, Any]]) -> dict[str, Any]:
+        self._validate_samples(samples)
+        input_wavs = [sample["input_wav.pth"] for sample in samples]
+        for key in _OPTIONAL_TENSOR_FIELDS:
+            present = sum(key in sample for sample in samples)
+            if present not in (0, len(samples)):
+                raise ValueError(f"{key} must be present for every sample or none")
+        optional = {
+            key: [sample[key] for sample in samples if key in sample]
+            for key in _OPTIONAL_TENSOR_FIELDS
+        }
+        input_wav = self._pad_cat(input_wavs)
+        input_wav_lens = torch.tensor(
+            [int(self._as_batched(tensor).size(-1)) for tensor in input_wavs],
+            dtype=torch.long,
+        )
+        names: list[str] = []
+        for sample in samples:
+            if "names.pickle" in sample:
+                name = sample["names.pickle"]
+                if isinstance(name, list):
+                    names.extend(str(value) for value in name)
+                else:
+                    names.append(str(name))
+            elif "__key__" in sample:
+                names.append(str(sample["__key__"]))
+        batch: dict[str, Any] = {
+            "input_wav": input_wav.float(),
+            "input_wav_lens": input_wav_lens,
+            "sr": samples[0].get("sr.index", 48_000),
+            "names": names,
+        }
+        output_names = {
+            "noisy_input_wav.pth": ("noisy_input_wav", False),
+            "noisy_input_wav16k.pth": ("noisy_input_wav16k", False),
+            "clean_mixture.pth": ("clean_mixture", True),
+            "clean_16k_mixture.pth": ("clean_16k_mixture", True),
+            "noisy_mixture.pth": ("noisy_mixture", True),
+            "noisy_16k_mixture.pth": ("noisy_16k_mixture", True),
+        }
+        for payload_key, tensors in optional.items():
+            if not tensors:
+                continue
+            output_key, squeeze_channel = output_names[payload_key]
+            value = self._pad_cat(tensors)
+            batch[output_key] = value.squeeze(1).float() if squeeze_channel else value.float()
+        return batch

--- a/tests/test_preprocessed_dialogue_datamodule.py
+++ b/tests/test_preprocessed_dialogue_datamodule.py
@@ -1,0 +1,433 @@
+import io
+import importlib
+import gzip
+import os
+from pathlib import Path
+import shlex
+import sys
+import tarfile
+
+import pytest
+import torch
+
+
+pytestmark = [
+    pytest.mark.filterwarnings("ignore:builtin type Swig.*:DeprecationWarning"),
+    pytest.mark.filterwarnings("ignore:builtin type swigvarlink.*:DeprecationWarning"),
+]
+
+
+def preprocessed_datamodule_class():
+    module = importlib.import_module(
+        "sidon.data.preprocess.preprocessed_dialogue_datamodule"
+    )
+    return module.PreprocessedDialogueDataModule
+
+
+def add_member(archive: tarfile.TarFile, name: str, payload: bytes) -> None:
+    info = tarfile.TarInfo(name)
+    info.size = len(payload)
+    archive.addfile(info, io.BytesIO(payload))
+
+
+def tensor_bytes(tensor: torch.Tensor) -> bytes:
+    buffer = io.BytesIO()
+    torch.save(tensor, buffer)
+    return buffer.getvalue()
+
+
+class MaliciousPayload:
+    def __init__(self, command: str) -> None:
+        self.command = command
+
+    def __reduce__(self):
+        return os.system, (self.command,)
+
+
+def write_fixture_shard(root: Path) -> None:
+    shard = root / "fixture.tar"
+    with tarfile.open(shard, "w") as archive:
+        for index in range(2):
+            key = f"fixture-{index}"
+            clean = torch.zeros((2, 480_000), dtype=torch.float32)
+            clean[index, :100] = 0.25
+            mixture = torch.zeros(320_000, dtype=torch.float32)
+            mixture[:100] = 0.125
+            add_member(archive, f"{key}.input_wav.pth", tensor_bytes(clean))
+            add_member(
+                archive,
+                f"{key}.noisy_16k_mixture.pth",
+                tensor_bytes(mixture),
+            )
+            add_member(archive, f"{key}.sr.index", b"24000")
+
+
+def strict_datamodule(root: Path, *, batch_size: int = 1):
+    PreprocessedDialogueDataModule = preprocessed_datamodule_class()
+    return PreprocessedDialogueDataModule(
+        train_urls=[str(root)],
+        val_urls=[str(root)],
+        batch_size=batch_size,
+        val_batch_size=batch_size,
+        required_sample_rate=24_000,
+        expected_duration_seconds=20,
+        required_input_channels=2,
+        require_noisy_16k_mixture=True,
+    )
+
+
+def test_preprocessed_loader_does_not_import_raw_augmentation_dependencies(
+    tmp_path: Path,
+) -> None:
+    PreprocessedDialogueDataModule = preprocessed_datamodule_class()
+
+    assert "sidon.data.preprocess.functional_degrations" not in sys.modules
+    write_fixture_shard(tmp_path)
+    datamodule = PreprocessedDialogueDataModule(
+        train_urls=[str(tmp_path)],
+        val_urls=[str(tmp_path)],
+        batch_size=2,
+        val_batch_size=2,
+        train_num_workers=0,
+        val_num_workers=0,
+        preprocessed=True,
+        is_s3=False,
+        required_sample_rate=24_000,
+        expected_duration_seconds=20,
+        required_input_channels=2,
+        require_noisy_16k_mixture=True,
+    )
+
+    datamodule.setup("fit")
+    batch = next(iter(datamodule.train_dataset))
+
+    assert batch["input_wav"].shape == (2, 2, 480_000)
+    assert batch["input_wav_lens"].tolist() == [480_000, 480_000]
+    assert batch["noisy_16k_mixture"].shape == (2, 320_000)
+    assert batch["sr"] == 24_000
+
+
+def test_legacy_dialogue_configs_keep_legacy_loader() -> None:
+    root = Path(__file__).resolve().parents[1]
+    target = (
+        "_target_: "
+        "sidon.data.preprocess.dialogue_datamodule.PreprocessedDialogueDataModule"
+    )
+
+    for config_name in ("dialogue_preprocessed.yaml", "dialogue_preprocessed_120s.yaml"):
+        config = root / "config" / "data" / config_name
+        assert target in config.read_text(encoding="utf-8")
+
+
+def test_lazy_webdataset_exports_preserve_public_api() -> None:
+    data_package = importlib.import_module("sidon.data")
+    preprocess_package = importlib.import_module("sidon.data.preprocess")
+
+    assert "WebDatasetDataModule" in data_package.__all__
+    assert "WebDatasetDataModule" in preprocess_package.__all__
+
+
+def test_strict_contract_rejects_non_finite_or_missing_payloads(
+    tmp_path: Path,
+) -> None:
+    PreprocessedDialogueDataModule = preprocessed_datamodule_class()
+
+    datamodule = PreprocessedDialogueDataModule(
+        train_urls=[str(tmp_path)],
+        val_urls=[str(tmp_path)],
+        batch_size=1,
+        val_batch_size=1,
+        required_sample_rate=24_000,
+        expected_duration_seconds=20,
+        required_input_channels=2,
+        require_noisy_16k_mixture=True,
+    )
+    clean = torch.zeros((2, 480_000), dtype=torch.float32)
+    mixture = torch.zeros(320_000, dtype=torch.float32)
+    mixture[0] = torch.inf
+
+    with pytest.raises(ValueError, match="finite"):
+        datamodule.collate_fn(
+            [
+                {
+                    "input_wav.pth": clean,
+                    "noisy_16k_mixture.pth": mixture,
+                    "sr.index": 24_000,
+                }
+            ]
+        )
+    with pytest.raises(ValueError, match="noisy_16k_mixture.pth"):
+        datamodule.collate_fn(
+            [{"input_wav.pth": clean, "sr.index": 24_000}]
+        )
+
+
+def test_collate_rejects_optional_payload_present_for_only_part_of_batch(
+    tmp_path: Path,
+) -> None:
+    PreprocessedDialogueDataModule = preprocessed_datamodule_class()
+    datamodule = PreprocessedDialogueDataModule(
+        train_urls=[str(tmp_path)],
+        val_urls=[str(tmp_path)],
+        batch_size=2,
+        val_batch_size=2,
+    )
+    clean = torch.zeros((2, 480_000), dtype=torch.float32)
+
+    with pytest.raises(ValueError, match="noisy_mixture.pth.*every sample"):
+        datamodule.collate_fn(
+            [
+                {
+                    "input_wav.pth": clean,
+                    "noisy_mixture.pth": torch.zeros(480_000),
+                    "sr.index": 24_000,
+                },
+                {"input_wav.pth": clean, "sr.index": 24_000},
+            ]
+        )
+
+
+@pytest.mark.parametrize(
+    ("payload_key", "payload"),
+    (
+        ("input_wav.pth", torch.zeros((1, 2, 8))),
+        ("noisy_mixture.pth", torch.zeros((1, 1, 8))),
+    ),
+)
+def test_collate_rejects_hidden_inner_batch_dimension(
+    tmp_path: Path,
+    payload_key: str,
+    payload: torch.Tensor,
+) -> None:
+    PreprocessedDialogueDataModule = preprocessed_datamodule_class()
+    datamodule = PreprocessedDialogueDataModule(
+        train_urls=[str(tmp_path)],
+        val_urls=[str(tmp_path)],
+        batch_size=1,
+        val_batch_size=1,
+    )
+    sample = {
+        "input_wav.pth": torch.zeros((2, 8)),
+        "sr.index": 24_000,
+        payload_key: payload,
+    }
+
+    with pytest.raises(ValueError, match="must not contain an inner batch dimension"):
+        datamodule.collate_fn([sample])
+
+
+def test_get_urls_shell_quotes_valid_s3_uris(tmp_path: Path) -> None:
+    get_urls = importlib.import_module("sidon.data.datamodule").get_urls
+    uris = (
+        "s3://bucket/dialogue shard.tar",
+        "s3://bucket/dialogue;touch /tmp/not-executed.tar",
+    )
+    manifest = tmp_path / "s3.txt"
+    manifest.write_text("\n".join(uris), encoding="utf-8")
+
+    urls = get_urls(str(manifest))
+
+    assert len(urls) == len(uris)
+    for url, uri in zip(urls, uris):
+        assert shlex.split(url.removeprefix("pipe:")) == [
+            "aws",
+            "--endpoint-url",
+            "https://s3ds.mdx.jp",
+            "s3",
+            "cp",
+            uri,
+            "-",
+        ]
+
+
+@pytest.mark.parametrize(
+    "uri",
+    ("https://bucket/shard.tar", "s3:///shard.tar", "s3://bucket"),
+)
+def test_get_urls_rejects_invalid_s3_uris(tmp_path: Path, uri: str) -> None:
+    get_urls = importlib.import_module("sidon.data.datamodule").get_urls
+    manifest = tmp_path / "s3.txt"
+    manifest.write_text(uri, encoding="utf-8")
+
+    with pytest.raises(ValueError, match="S3 URI"):
+        get_urls(str(manifest))
+
+
+def test_safe_dialogue_decoder_loads_allowlisted_tensor() -> None:
+    decoder = importlib.import_module(
+        "sidon.data.preprocess.preprocessed_dialogue_datamodule"
+    ).safe_dialogue_decoder
+    expected = torch.arange(4, dtype=torch.float32)
+
+    actual = decoder(".input_wav.pth", tensor_bytes(expected))
+
+    assert isinstance(actual, torch.Tensor)
+    assert torch.equal(actual, expected)
+
+
+def test_safe_dialogue_decoder_rejects_unknown_tensor_member() -> None:
+    decoder = importlib.import_module(
+        "sidon.data.preprocess.preprocessed_dialogue_datamodule"
+    ).safe_dialogue_decoder
+
+    with pytest.raises(ValueError, match="not allowlisted"):
+        decoder(".unexpected.pth", tensor_bytes(torch.zeros(1)))
+
+
+def test_safe_dialogue_decoder_rejects_pickle_code_execution(
+    tmp_path: Path,
+) -> None:
+    decoder = importlib.import_module(
+        "sidon.data.preprocess.preprocessed_dialogue_datamodule"
+    ).safe_dialogue_decoder
+    marker = tmp_path / "executed"
+    buffer = io.BytesIO()
+    torch.save(MaliciousPayload(f"touch {shlex.quote(str(marker))}"), buffer)
+
+    with pytest.raises(ValueError, match="safe tensor"):
+        decoder(".input_wav.pth", buffer.getvalue())
+
+    assert not marker.exists()
+
+
+def test_safe_dialogue_decoder_rejects_pickle_members() -> None:
+    decoder = importlib.import_module(
+        "sidon.data.preprocess.preprocessed_dialogue_datamodule"
+    ).safe_dialogue_decoder
+
+    with pytest.raises(ValueError, match="pickle payloads are disabled"):
+        decoder(".names.pickle", b"not loaded")
+
+
+def test_loader_rejects_unsafe_record_key_before_decoding(tmp_path: Path) -> None:
+    shard = tmp_path / "unsafe-key.tar"
+    with tarfile.open(shard, "w") as archive:
+        add_member(
+            archive,
+            "../escape.input_wav.pth",
+            tensor_bytes(torch.zeros((2, 480_000), dtype=torch.float32)),
+        )
+    datamodule = strict_datamodule(tmp_path)
+    datamodule.setup("fit")
+
+    with pytest.raises(ValueError, match="unsafe record key"):
+        next(iter(datamodule.train_dataset))
+
+
+def test_loader_rejects_dotted_record_key_before_grouping(tmp_path: Path) -> None:
+    shard = tmp_path / "dotted-key.tar"
+    with tarfile.open(shard, "w") as archive:
+        add_member(
+            archive,
+            "speaker.001.input_wav.pth",
+            tensor_bytes(torch.zeros((2, 480_000), dtype=torch.float32)),
+        )
+    datamodule = strict_datamodule(tmp_path)
+    datamodule.setup("fit")
+
+    with pytest.raises(ValueError, match="unsafe record key"):
+        next(iter(datamodule.train_dataset))
+
+
+def test_loader_rejects_declared_oversized_member_before_reading(
+    tmp_path: Path,
+) -> None:
+    shard = tmp_path / "oversized.tar"
+    info = tarfile.TarInfo("fixture.input_wav.pth")
+    info.size = 64 * 1024 * 1024 + 1
+    shard.write_bytes(info.tobuf(format=tarfile.GNU_FORMAT) + (b"\0" * 1024))
+    datamodule = strict_datamodule(tmp_path)
+    datamodule.setup("fit")
+
+    with pytest.raises(ValueError, match="exceeds size limit"):
+        next(iter(datamodule.train_dataset))
+
+
+@pytest.mark.parametrize(
+    "type_flag",
+    (tarfile.GNUTYPE_LONGNAME, tarfile.XHDTYPE),
+)
+def test_loader_rejects_extended_header_before_payload_read(
+    tmp_path: Path,
+    type_flag: bytes,
+) -> None:
+    shard = tmp_path / "extended-header.tar"
+    info = tarfile.TarInfo("././@LongLink")
+    info.type = type_flag
+    info.size = 64 * 1024 * 1024 + 1
+    shard.write_bytes(info.tobuf(format=tarfile.GNU_FORMAT) + (b"\0" * 1024))
+    datamodule = strict_datamodule(tmp_path)
+    datamodule.setup("fit")
+
+    with pytest.raises(ValueError, match="extension header exceeds size limit"):
+        next(iter(datamodule.train_dataset))
+
+
+def test_loader_rejects_sparse_header_before_payload_read(tmp_path: Path) -> None:
+    shard = tmp_path / "sparse-header.tar"
+    info = tarfile.TarInfo("fixture.input_wav.pth")
+    info.type = tarfile.GNUTYPE_SPARSE
+    info.size = 1
+    shard.write_bytes(info.tobuf(format=tarfile.GNU_FORMAT) + (b"\0" * 1024))
+    datamodule = strict_datamodule(tmp_path)
+    datamodule.setup("fit")
+
+    with pytest.raises(ValueError, match="sparse entries are disabled"):
+        next(iter(datamodule.train_dataset))
+
+
+@pytest.mark.parametrize(
+    "pax_headers",
+    (
+        {
+            "GNU.sparse.size": "1",
+            "GNU.sparse.offset": "0",
+            "GNU.sparse.numbytes": "1",
+        },
+        {"GNU.sparse.map": "0,1"},
+        {"GNU.sparse.major": "1", "GNU.sparse.minor": "0"},
+    ),
+)
+def test_loader_rejects_pax_sparse_variants(
+    tmp_path: Path,
+    pax_headers: dict[str, str],
+) -> None:
+    shard = tmp_path / "pax-sparse.tar"
+    info = tarfile.TarInfo("fixture.input_wav.pth")
+    info.size = 1
+    info.pax_headers = pax_headers
+    with tarfile.open(shard, "w", format=tarfile.PAX_FORMAT) as archive:
+        archive.addfile(info, io.BytesIO(b"\0"))
+    datamodule = strict_datamodule(tmp_path)
+    datamodule.setup("fit")
+
+    with pytest.raises(ValueError, match="sparse entries are disabled"):
+        next(iter(datamodule.train_dataset))
+
+
+def test_loader_rejects_non_regular_member(tmp_path: Path) -> None:
+    shard = tmp_path / "link-member.tar"
+    info = tarfile.TarInfo("fixture.input_wav.pth")
+    info.type = tarfile.SYMTYPE
+    info.linkname = "other.input_wav.pth"
+    with tarfile.open(shard, "w") as archive:
+        archive.addfile(info)
+    datamodule = strict_datamodule(tmp_path)
+    datamodule.setup("fit")
+
+    with pytest.raises(ValueError, match="regular file"):
+        next(iter(datamodule.train_dataset))
+
+
+def test_loader_rejects_gzip_member_without_decompressing(tmp_path: Path) -> None:
+    shard = tmp_path / "gzip-member.tar"
+    compressed = gzip.compress(
+        tensor_bytes(torch.zeros((2, 480_000), dtype=torch.float32))
+    )
+    with tarfile.open(shard, "w") as archive:
+        add_member(archive, "fixture.input_wav.pth.gz", compressed)
+    datamodule = strict_datamodule(tmp_path)
+    datamodule.setup("fit")
+
+    with pytest.raises(ValueError, match="unsupported suffix"):
+        next(iter(datamodule.train_dataset))


### PR DESCRIPTION
## Summary
- add a channel-preserving strict loader for EEND DialogueSidon shards
- validate sample shape/rate/cardinality and safely decode allowlisted tensor members
- bound tar metadata/member reads and reject unsupported archive structures
- add an EEND-specific Hydra data config while preserving legacy loaders and exports

## Test plan
- `PYTHONPATH=src python -m pytest -q tests` (26 passed)
- `PYTHONPATH=src python -m compileall -q src/sidon/data tests`
- load EEND fixture batches as `(B,2,480000)` and `(B,320000)` at 24 kHz